### PR TITLE
Revert "Bump tzinfo from 1.2.6 to 2.0.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ end
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-  gem "tzinfo", "~> 2.0"
+  gem "tzinfo", "~> 1.2"
   gem "tzinfo-data"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     coffee-script (2.4.1)
@@ -13,7 +16,7 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.5)
     dnsruby (1.61.3)
       addressable (~> 2.5)
     em-websocket (0.5.1)
@@ -25,7 +28,7 @@ GEM
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.2)
+    ffi (1.12.1)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (204)
@@ -199,9 +202,9 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    multi_json (1.14.1)
+    minitest (5.14.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.9)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
@@ -227,14 +230,16 @@ GEM
       faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (2.0.2)
-      concurrent-ruby (~> 1.0)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
     tzinfo-data (1.2019.3)
       tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby
@@ -244,7 +249,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   jekyll-sitemap
   minima (~> 2.5)
-  tzinfo (~> 2.0)
+  tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
 


### PR DESCRIPTION
Reverts danmurf/murfittnet-jekyll#9